### PR TITLE
Add Reactive events to CLGeocoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+
+---
+
+## Unreleased
+
+* Add Reactive events to CLGeocoder. #37

--- a/RxCoreLocation.xcodeproj/project.pbxproj
+++ b/RxCoreLocation.xcodeproj/project.pbxproj
@@ -17,6 +17,10 @@
 		35B742301F82A5E000829B21 /* Quick.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 35B7422E1F82A5E000829B21 /* Quick.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		35B742311F82A5EC00829B21 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 35B7422D1F82A5DF00829B21 /* Nimble.framework */; };
 		35B742321F82A5EC00829B21 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 35B7422E1F82A5E000829B21 /* Quick.framework */; };
+		6AE878E92515080400C14D48 /* CLGeocoderEvents+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AE878E82515080400C14D48 /* CLGeocoderEvents+Rx.swift */; };
+		6AE878EA25150A3A00C14D48 /* CLGeocoderEvents+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AE878E82515080400C14D48 /* CLGeocoderEvents+Rx.swift */; };
+		6AE878EB25150A3A00C14D48 /* CLGeocoderEvents+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AE878E82515080400C14D48 /* CLGeocoderEvents+Rx.swift */; };
+		6AE878EC25150A3A00C14D48 /* CLGeocoderEvents+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AE878E82515080400C14D48 /* CLGeocoderEvents+Rx.swift */; };
 		A85013AF204F093C00094A90 /* RxKeyPaths.swift in Sources */ = {isa = PBXBuildFile; fileRef = A85013AE204F093C00094A90 /* RxKeyPaths.swift */; };
 		A85013B0204F174100094A90 /* RxKeyPaths.swift in Sources */ = {isa = PBXBuildFile; fileRef = A85013AE204F093C00094A90 /* RxKeyPaths.swift */; };
 		A85013B1204F174100094A90 /* RxKeyPaths.swift in Sources */ = {isa = PBXBuildFile; fileRef = A85013AE204F093C00094A90 /* RxKeyPaths.swift */; };
@@ -104,6 +108,7 @@
 		35B7422E1F82A5E000829B21 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/iOS/Quick.framework; sourceTree = "<group>"; };
 		35B742341F82A61D00829B21 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/Mac/Nimble.framework; sourceTree = "<group>"; };
 		35B742351F82A61E00829B21 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/Mac/Quick.framework; sourceTree = "<group>"; };
+		6AE878E82515080400C14D48 /* CLGeocoderEvents+Rx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CLGeocoderEvents+Rx.swift"; sourceTree = "<group>"; };
 		A85013AE204F093C00094A90 /* RxKeyPaths.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RxKeyPaths.swift; sourceTree = "<group>"; };
 		C44FC2851FB59E150051CCA2 /* ForwardsEventsBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForwardsEventsBehavior.swift; sourceTree = "<group>"; };
 		C44FC2891FB59FC00051CCA2 /* HasEventsBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HasEventsBehavior.swift; sourceTree = "<group>"; };
@@ -251,6 +256,7 @@
 				C4B8B2051FA62049005E0A69 /* RxCLLocationManagerDelegateProxy.swift */,
 				C4B8B20A1FA646B7005E0A69 /* CLLocationManagerDelegateEvents+Rx.swift */,
 				C4BEE2631FB319670098BB4A /* CLLocationManagerEvents+Rx.swift */,
+				6AE878E82515080400C14D48 /* CLGeocoderEvents+Rx.swift */,
 				C4B8B20F1FA654A5005E0A69 /* Helpers.swift */,
 			);
 			name = Core;
@@ -516,6 +522,7 @@
 				C4B8B1FC1FA50C1E005E0A69 /* RxSelectors.swift in Sources */,
 				C4B8B20B1FA646B7005E0A69 /* CLLocationManagerDelegateEvents+Rx.swift in Sources */,
 				C4B8B2061FA62049005E0A69 /* RxCLLocationManagerDelegateProxy.swift in Sources */,
+				6AE878E92515080400C14D48 /* CLGeocoderEvents+Rx.swift in Sources */,
 				C4BEE2641FB319670098BB4A /* CLLocationManagerEvents+Rx.swift in Sources */,
 				A85013AF204F093C00094A90 /* RxKeyPaths.swift in Sources */,
 			);
@@ -530,6 +537,7 @@
 				C4B8B1FF1FA50C1E005E0A69 /* RxSelectors.swift in Sources */,
 				C4B8B20E1FA646B7005E0A69 /* CLLocationManagerDelegateEvents+Rx.swift in Sources */,
 				C4B8B2091FA62049005E0A69 /* RxCLLocationManagerDelegateProxy.swift in Sources */,
+				6AE878EC25150A3A00C14D48 /* CLGeocoderEvents+Rx.swift in Sources */,
 				C4BEE2671FB319670098BB4A /* CLLocationManagerEvents+Rx.swift in Sources */,
 				A85013B2204F174200094A90 /* RxKeyPaths.swift in Sources */,
 			);
@@ -544,6 +552,7 @@
 				C4B8B1FD1FA50C1E005E0A69 /* RxSelectors.swift in Sources */,
 				C4B8B20C1FA646B7005E0A69 /* CLLocationManagerDelegateEvents+Rx.swift in Sources */,
 				C4B8B2071FA62049005E0A69 /* RxCLLocationManagerDelegateProxy.swift in Sources */,
+				6AE878EA25150A3A00C14D48 /* CLGeocoderEvents+Rx.swift in Sources */,
 				C4BEE2651FB319670098BB4A /* CLLocationManagerEvents+Rx.swift in Sources */,
 				A85013B0204F174100094A90 /* RxKeyPaths.swift in Sources */,
 			);
@@ -558,6 +567,7 @@
 				C4B8B1FE1FA50C1E005E0A69 /* RxSelectors.swift in Sources */,
 				C4B8B20D1FA646B7005E0A69 /* CLLocationManagerDelegateEvents+Rx.swift in Sources */,
 				C4B8B2081FA62049005E0A69 /* RxCLLocationManagerDelegateProxy.swift in Sources */,
+				6AE878EB25150A3A00C14D48 /* CLGeocoderEvents+Rx.swift in Sources */,
 				C4BEE2661FB319670098BB4A /* CLLocationManagerEvents+Rx.swift in Sources */,
 				A85013B1204F174100094A90 /* RxKeyPaths.swift in Sources */,
 			);

--- a/RxCoreLocation.xcodeproj/project.pbxproj
+++ b/RxCoreLocation.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		35B742301F82A5E000829B21 /* Quick.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 35B7422E1F82A5E000829B21 /* Quick.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		35B742311F82A5EC00829B21 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 35B7422D1F82A5DF00829B21 /* Nimble.framework */; };
 		35B742321F82A5EC00829B21 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 35B7422E1F82A5E000829B21 /* Quick.framework */; };
+		6A744A4D252E645D0044A9F3 /* EventualEventBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A744A4C252E645D0044A9F3 /* EventualEventBehavior.swift */; };
+		6AC1E130252E66A00051E5B4 /* RxCLGeocoderSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC1E12F252E66A00051E5B4 /* RxCLGeocoderSpec.swift */; };
 		6AE878E92515080400C14D48 /* CLGeocoderEvents+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AE878E82515080400C14D48 /* CLGeocoderEvents+Rx.swift */; };
 		6AE878EA25150A3A00C14D48 /* CLGeocoderEvents+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AE878E82515080400C14D48 /* CLGeocoderEvents+Rx.swift */; };
 		6AE878EB25150A3A00C14D48 /* CLGeocoderEvents+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AE878E82515080400C14D48 /* CLGeocoderEvents+Rx.swift */; };
@@ -108,6 +110,8 @@
 		35B7422E1F82A5E000829B21 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/iOS/Quick.framework; sourceTree = "<group>"; };
 		35B742341F82A61D00829B21 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/Mac/Nimble.framework; sourceTree = "<group>"; };
 		35B742351F82A61E00829B21 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/Mac/Quick.framework; sourceTree = "<group>"; };
+		6A744A4C252E645D0044A9F3 /* EventualEventBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventualEventBehavior.swift; sourceTree = "<group>"; };
+		6AC1E12F252E66A00051E5B4 /* RxCLGeocoderSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RxCLGeocoderSpec.swift; sourceTree = "<group>"; };
 		6AE878E82515080400C14D48 /* CLGeocoderEvents+Rx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CLGeocoderEvents+Rx.swift"; sourceTree = "<group>"; };
 		A85013AE204F093C00094A90 /* RxKeyPaths.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RxKeyPaths.swift; sourceTree = "<group>"; };
 		C44FC2851FB59E150051CCA2 /* ForwardsEventsBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForwardsEventsBehavior.swift; sourceTree = "<group>"; };
@@ -220,6 +224,8 @@
 			isa = PBXGroup;
 			children = (
 				3549BB8A1DA38C0A00C63030 /* RxCoreLocationSpec.swift */,
+				6AC1E12F252E66A00051E5B4 /* RxCLGeocoderSpec.swift */,
+				6A744A4C252E645D0044A9F3 /* EventualEventBehavior.swift */,
 				C44FC2851FB59E150051CCA2 /* ForwardsEventsBehavior.swift */,
 				C44FC2891FB59FC00051CCA2 /* HasEventsBehavior.swift */,
 				C4B87A8D1FB476EC00E250BD /* RxTest+Extension.swift */,
@@ -577,6 +583,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6A744A4D252E645D0044A9F3 /* EventualEventBehavior.swift in Sources */,
+				6AC1E130252E66A00051E5B4 /* RxCLGeocoderSpec.swift in Sources */,
 				C44FC2861FB59E150051CCA2 /* ForwardsEventsBehavior.swift in Sources */,
 				3549BB8B1DA38C0A00C63030 /* RxCoreLocationSpec.swift in Sources */,
 				C4B87A8E1FB476EC00E250BD /* RxTest+Extension.swift in Sources */,

--- a/Sources/CLGeocoderEvents+Rx.swift
+++ b/Sources/CLGeocoderEvents+Rx.swift
@@ -41,4 +41,62 @@ extension Reactive where Base: CLGeocoder {
             }
         }.unwrap()
     }
+
+    /// Reactive wrapper for `CLGeocoder`.`geocodeAddressString(_:completionHandler:)`
+    /// used to search for placemark
+    public func placemarks(with addressString: String) -> Observable<[CLPlacemark]> {
+        return Observable.create { [base] observer in
+            base.geocodeAddressString(addressString) { placemarks, _ in
+                guard let placemarks = placemarks else {
+                    observer.onError(NSError(domain: CLError.errorDomain, code: CLError.geocodeFoundNoResult.rawValue, userInfo: nil))
+                    return
+                }
+
+                observer.onNext(placemarks)
+                observer.onCompleted()
+            }
+            return Disposables.create {
+                base.cancelGeocode()
+            }
+        }
+    }
+
+    /// Reactive wrapper for `CLGeocoder`.`geocodeAddressString(_:in:completionHandler:)`
+    /// used to search for placemark
+    public func placemarks(with addressString: String, in region: CLRegion?) -> Observable<[CLPlacemark]> {
+        return Observable.create { [base] observer in
+            base.geocodeAddressString(addressString, in: region) { placemarks, _ in
+                guard let placemarks = placemarks else {
+                    observer.onError(NSError(domain: CLError.errorDomain, code: CLError.geocodeFoundNoResult.rawValue, userInfo: nil))
+                    return
+                }
+
+                observer.onNext(placemarks)
+                observer.onCompleted()
+            }
+            return Disposables.create {
+                base.cancelGeocode()
+            }
+        }
+    }
+
+    /// Reactive wrapper for `CLGeocoder`.`geocodeAddressString(_:in:preferredLocale:completionHandler:)`
+    /// used to search for placemark
+    @available(iOS 11.0, OSX 10.13, watchOSApplicationExtension 4.0, tvOS 11.0, *)
+    public func placemarks(with addressString: String, in region: CLRegion?, preferredLocale locale: Locale?) -> Observable<[CLPlacemark]> {
+        return Observable.create { [base] observer in
+            base.geocodeAddressString(addressString, in: region, preferredLocale: locale) { placemarks, _ in
+                guard let placemarks = placemarks else {
+                    observer.onError(NSError(domain: CLError.errorDomain, code: CLError.geocodeFoundNoResult.rawValue, userInfo: nil))
+                    return
+                }
+
+                observer.onNext(placemarks)
+                observer.onCompleted()
+            }
+            return Disposables.create {
+                base.cancelGeocode()
+            }
+        }
+    }
 }

--- a/Sources/CLGeocoderEvents+Rx.swift
+++ b/Sources/CLGeocoderEvents+Rx.swift
@@ -1,0 +1,42 @@
+//
+//  CLGeocoderEvents+Rx.swift
+//  RxCoreLocation
+//
+//  Created by Zsolt Kovacs on 18.09.20.
+//  Copyright © 2020 RxCoreLocation. All rights reserved.
+//
+
+import CoreLocation
+#if !RX_NO_MODULE
+    import RxSwift
+    import RxCocoa
+#endif
+
+extension Reactive where Base: CLGeocoder {
+    /// Reactive wrapper for `CLGeocoder`.`reverseGeocodeLocation(_:completionHandler:)`
+    /// used to search for placemark
+    public func placemark(with location: CLLocation) -> Observable<CLPlacemark> {
+        return Observable.create { [base] observer in
+            base.reverseGeocodeLocation(location) { placemarks, _ in
+                observer.onNext(placemarks?.first)
+            }
+            return Disposables.create {
+                observer.onCompleted()
+            }
+        }.unwrap()
+    }
+
+    /// Reactive wrapper for `CLGeocoder`.`reverseGeocodeLocation(_:preferredLocale:completionHandler:)`
+    /// used to search for placemark
+    @available(iOS 11.0, OSX 10.13, watchOSApplicationExtension 4.0, tvOS 11.0, *)
+    public func placemark(with location: CLLocation, preferredLocale: Locale) -> Observable<CLPlacemark> {
+        return Observable.create { [base] observer in
+            base.reverseGeocodeLocation(location, preferredLocale: preferredLocale) { placemarks, _ in
+                observer.onNext(placemarks?.first)
+            }
+            return Disposables.create {
+                observer.onCompleted()
+            }
+        }.unwrap()
+    }
+}

--- a/Sources/CLGeocoderEvents+Rx.swift
+++ b/Sources/CLGeocoderEvents+Rx.swift
@@ -21,6 +21,7 @@ extension Reactive where Base: CLGeocoder {
                 observer.onNext(placemarks?.first)
             }
             return Disposables.create {
+                base.cancelGeocode()
                 observer.onCompleted()
             }
         }.unwrap()
@@ -35,6 +36,7 @@ extension Reactive where Base: CLGeocoder {
                 observer.onNext(placemarks?.first)
             }
             return Disposables.create {
+                base.cancelGeocode()
                 observer.onCompleted()
             }
         }.unwrap()

--- a/Sources/CLLocationManagerEvents+Rx.swift
+++ b/Sources/CLLocationManagerEvents+Rx.swift
@@ -55,40 +55,15 @@ extension Reactive where Base: CLLocationManager {
     }
     /// Reactive Observable for CLPlacemark
     public var placemark: Observable<CLPlacemark> {
-        return location.unwrap().flatMap(placemark(with:))
-    }
-    /// Private reactive wrapper for `CLGeocoder`.`reverseGeocodeLocation(_:completionHandler:)`
-    /// used to search for placemark
-    private func placemark(with location: CLLocation) -> Observable<CLPlacemark> {
-        return Observable.create { observer in
-            let geocoder = CLGeocoder()
-            geocoder.reverseGeocodeLocation(location) { placemarks, _ in
-                observer.onNext(placemarks?.first)
-            }
-            return Disposables.create {
-                observer.onCompleted()
-            }
-        }.unwrap()
+        let geocoder = CLGeocoder()
+        return location.unwrap().flatMap { geocoder.rx.placemark(with: $0) }
     }
 
     /// Reactive Observable for CLPlacemark with a given locale
     @available(iOS 11.0, OSX 10.13, watchOSApplicationExtension 4.0, tvOS 11.0, *)
     public func placemark(preferredLocale: Locale) -> Observable<CLPlacemark> {
-        return location.unwrap().flatMap { self.placemark(with: $0, preferredLocale: preferredLocale) }
-    }
-    /// Private reactive wrapper for `CLGeocoder`.`reverseGeocodeLocation(_:preferredLocale:completionHandler:)`
-    /// used to search for placemark
-    @available(iOS 11.0, OSX 10.13, watchOSApplicationExtension 4.0, tvOS 11.0, *)
-    private func placemark(with location: CLLocation, preferredLocale: Locale) -> Observable<CLPlacemark> {
-        return Observable.create { observer in
-            let geocoder = CLGeocoder()
-            geocoder.reverseGeocodeLocation(location, preferredLocale: preferredLocale) { placemarks, _ in
-                observer.onNext(placemarks?.first)
-            }
-            return Disposables.create {
-                observer.onCompleted()
-            }
-        }.unwrap()
+        let geocoder = CLGeocoder()
+        return location.unwrap().flatMap { geocoder.rx.placemark(with: $0, preferredLocale: preferredLocale) }
     }
 
     /// Reactive Observable for `headingFilter`

--- a/Tests/EventualEventBehavior.swift
+++ b/Tests/EventualEventBehavior.swift
@@ -1,0 +1,54 @@
+//
+//  EventualEventBehavior.swift
+//  RxCoreLocation
+//
+//  Created by Zsolt Kovacs on 07.10.20.
+//  Copyright © 2020 RxCoreLocation. All rights reserved.
+//
+
+import Foundation
+import Quick
+import Nimble
+import RxSwift
+import RxCocoa
+import RxTest
+import CoreLocation
+@testable import RxCoreLocation
+
+struct EventualEventBehaviorContext<T> {
+    let scheduler: TestScheduler
+    let observable: Observable<T>
+    init(_ scheduler: TestScheduler, _ observable: Observable<T>) {
+        self.scheduler = scheduler
+        self.observable = observable
+    }
+}
+
+class EventualEventBehavior<T>: Quick.Behavior<EventualEventBehaviorContext<T>> {
+    override class func spec(_ context: @escaping () -> EventualEventBehaviorContext<T>) {
+        var scheduler: TestScheduler!
+        var observable: Observable<T>!
+
+        beforeEach {
+            let cxt = context()
+            scheduler = cxt.scheduler
+            observable = cxt.observable
+        }
+
+        afterEach {
+            scheduler = nil
+            observable = nil
+        }
+
+        describe("Has Events Behavior") {
+            it("Actually got the event") {
+                SharingScheduler.mock(scheduler: scheduler) {
+                    let recorded = scheduler.record(source: observable)
+                    scheduler.start()
+                    expect(recorded.events.count).toEventually(equal(1))
+                }
+            }
+        }
+    }
+}
+

--- a/Tests/RxCLGeocoderSpec.swift
+++ b/Tests/RxCLGeocoderSpec.swift
@@ -1,0 +1,72 @@
+//
+//  CLGeocoderSpec.swift
+//  RxCoreLocation
+//
+//  Created by Zsolt Kovacs on 07.10.20.
+//  Copyright © 2020 RxCoreLocation. All rights reserved.
+//
+
+import Quick
+import Nimble
+import CoreLocation
+import RxSwift
+import RxCocoa
+import RxTest
+@testable import RxCoreLocation
+
+class RxCLGeocoderSpec: QuickSpec {
+
+    override func spec() {
+        var sut: CLGeocoder!
+        var scheduler: TestScheduler!
+
+        beforeEach {
+            sut = CLGeocoder()
+            scheduler = TestScheduler(initialClock: 0)
+        }
+
+        afterEach {
+            sut = nil
+            scheduler = nil
+        }
+
+        itBehavesLike(EventualEventBehavior<CLPlacemark>.self) {
+            let location = CLLocation(latitude: 47.2, longitude: 8.52)
+            return EventualEventBehaviorContext(scheduler, sut.rx.placemark(with: location))
+        }
+
+        if #available(iOS 11.0, OSX 10.13, watchOSApplicationExtension 4.0, tvOS 11.0, *) {
+            itBehavesLike(EventualEventBehavior<CLPlacemark>.self) {
+                let location = CLLocation(latitude: 47.200364, longitude: 8.522604)
+                let locale = Locale.current
+                return EventualEventBehaviorContext(scheduler, sut.rx.placemark(with: location, preferredLocale: locale))
+            }
+        }
+
+        itBehavesLike(EventualEventBehavior<[CLPlacemark]>.self) {
+            let addressString = "Palais des Nations, 1211 Genève"
+            return EventualEventBehaviorContext(scheduler, sut.rx.placemarks(with: addressString))
+        }
+
+        itBehavesLike(EventualEventBehavior<[CLPlacemark]>.self) {
+            let addressString = "Palais des Nations, 1211 Genève"
+            let region = CLCircularRegion(
+                center: CLLocationCoordinate2D(latitude: 46.226328, longitude: 6.141381),
+                radius: 500,
+                identifier: "Geneva region")
+            return EventualEventBehaviorContext(scheduler, sut.rx.placemarks(with: addressString, in: region))
+        }
+
+        if #available(iOS 11.0, OSX 10.13, watchOSApplicationExtension 4.0, tvOS 11.0, *) {
+            itBehavesLike(EventualEventBehavior<[CLPlacemark]>.self) {
+                let addressString = "Palais des Nations, 1211 Genève"
+                let region = CLCircularRegion(
+                    center: CLLocationCoordinate2D(latitude: 46.226328, longitude: 6.141381),
+                    radius: 500,
+                    identifier: "Geneva region")
+                let locale = Locale.current
+                return EventualEventBehaviorContext(scheduler, sut.rx.placemarks(with: addressString, in: region, preferredLocale: locale))
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #36 

I'm unsure of a few things:

0. How to update the non-existent changelog 😄 
1. How to add tests
2. Should we forward the error received inside the `CLGeocodeCompletionHandler`? It was not done before, however all methods on CLGeocoder have the following notice:

```
After initiating a forward-geocoding request, do not attempt to initiate another forward- or reverse-geocoding request. Geocoding requests are rate-limited for each app, so making too many requests in a short period of time may cause some of the requests to fail. When the maximum rate is exceeded, the geocoder passes an error object with the value CLError.Code.network to your completion handler.
```

